### PR TITLE
Use current route match service in ResponseWrapperSubscriber.

### DIFF
--- a/config/install/taxonomy.vocabulary.news_story_categories.yml
+++ b/config/install/taxonomy.vocabulary.news_story_categories.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'News Story Categories'
+vid: news_story_categories
+description: 'Taxonomy for AZ News Stories'
+weight: 0

--- a/news_legacy_feeds.services.yml
+++ b/news_legacy_feeds.services.yml
@@ -1,5 +1,6 @@
 services:
   news_legacy_feeds.response_wrapper_subscriber:
     class: Drupal\news_legacy_feeds\EventSubscriber\ResponseWrapperSubscriber
+    arguments: ['@current_route_match']
     tags:
       - { name: event_subscriber }

--- a/src/EventSubscriber/ResponseWrapperSubscriber.php
+++ b/src/EventSubscriber/ResponseWrapperSubscriber.php
@@ -26,7 +26,6 @@ class ResponseWrapperSubscriber implements EventSubscriberInterface {
     $this->routeMatch = $route_match;
   }
 
-
   public static function getSubscribedEvents() {
     // Corrected: Removed the empty return statement.
     // The priority -10 ensures this runs after most default system operations.

--- a/src/EventSubscriber/ResponseWrapperSubscriber.php
+++ b/src/EventSubscriber/ResponseWrapperSubscriber.php
@@ -2,42 +2,58 @@
 
 namespace Drupal\news_legacy_feeds\EventSubscriber;
 
+use Drupal\Core\Routing\RouteMatchInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class ResponseWrapperSubscriber implements EventSubscriberInterface {
 
-public static function getSubscribedEvents() {
-  // Corrected: Removed the empty return statement.
-  // The priority -10 ensures this runs after most default system operations.
-  return [
-    KernelEvents::RESPONSE => ['onResponse', -10],
-  ];
-}
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
 
-public function onResponse(ResponseEvent $event) {
-  $router = \Drupal::service('router');
-  $route = $router->match($event->getRequest()->getPathInfo());
-  $route_name = $route['_route'];
-  // Checking if the route belongs to a view and if the view is the one we're
-  // interested in.
-  if (
-    $route_name === 'view.news_deprecated_feeds_stories.category' ||
-    $route_name === 'view.news_deprecated_feeds_stories.website'
-  ) {
-  // if ($request->attributes->get('_view_id') === 'news_deprecated_feeds_terms') {
-    $response = $event->getResponse();
-
-    if ($response->headers->get('Content-Type') === 'application/json') {
-      $data = json_decode($response->getContent(), true);
-      $wrappedData = ['stories' => $data];
-      $response->setContent(json_encode($wrappedData));
-      $event->setResponse($response);
-    }
+  /**
+   * Constructs the ResponseWrapperSubscriber object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
   }
 
-}
+
+  public static function getSubscribedEvents() {
+    // Corrected: Removed the empty return statement.
+    // The priority -10 ensures this runs after most default system operations.
+    return [
+      KernelEvents::RESPONSE => ['onResponse', -10],
+    ];
+  }
+
+  public function onResponse(ResponseEvent $event) {
+    $route_name = $this->routeMatch->getRouteName();
+    // Checking if the route belongs to a view and if the view is the one we're
+    // interested in.
+    if (
+      $route_name === 'view.news_deprecated_feeds_stories.category' ||
+      $route_name === 'view.news_deprecated_feeds_stories.website'
+    ) {
+      // if ($request->attributes->get('_view_id') === 'news_deprecated_feeds_terms') {
+      $response = $event->getResponse();
+
+      if ($response->headers->get('Content-Type') === 'application/json') {
+        $data = json_decode($response->getContent(), true);
+        $wrappedData = ['stories' => $data];
+        $response->setContent(json_encode($wrappedData));
+        $event->setResponse($response);
+      }
+    }
+  }
 
 
 }


### PR DESCRIPTION
Noticed this exception getting thrown when I fat-fingered the path for the terms JSON feed:

```
Symfony\Component\Routing\Exception\ResourceNotFoundException: No routes found for "/feed/json/tems/all". in Drupal\Core\Routing\Router->matchRequest() (line 144 of /code/web/core/lib/Drupal/Core/Routing/Router.php).
```

I don't think we want that to happen.  Should be able to just return a normal 404, I think.

Here is the full stack trace:
```
#0 /code/web/core/lib/Drupal/Core/Routing/AccessAwareRouter.php(90): Drupal\Core\Routing\Router->matchRequest(Object(Symfony\Component\HttpFoundation\Request))
#1 /code/web/core/lib/Drupal/Core/Routing/AccessAwareRouter.php(144): Drupal\Core\Routing\AccessAwareRouter->matchRequest(Object(Symfony\Component\HttpFoundation\Request))
#2 /code/web/modules/custom/news_legacy_feeds/src/EventSubscriber/ResponseWrapperSubscriber.php(21): Drupal\Core\Routing\AccessAwareRouter->match('/feed/json/tems...')
#3 [internal function]: Drupal\news_legacy_feeds\EventSubscriber\ResponseWrapperSubscriber->onResponse(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#4 /code/web/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php(111): call_user_func(Array, Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#5 /code/vendor/symfony/http-kernel/HttpKernel.php(214): Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response')
#6 /code/vendor/symfony/http-kernel/HttpKernel.php(202): Symfony\Component\HttpKernel\HttpKernel->filterResponse(Object(Drupal\Core\Render\HtmlResponse), Object(Symfony\Component\HttpFoundation\Request), 2)
#7 /code/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 2)
#8 /code/web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#9 /code/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#10 /code/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#11 /code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#12 /code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#13 /code/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#14 /code/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#15 /code/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#16 /code/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\Core\StackMiddleware\AjaxPageState->handle(Object(Symfony\Component\HttpFoundation\Request), 2, true)
#17 /code/web/core/lib/Drupal/Core/EventSubscriber/DefaultExceptionHtmlSubscriber.php(166): Drupal\Core\StackMiddleware\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 2)
#18 /code/web/core/lib/Drupal/Core/EventSubscriber/CustomPageExceptionHtmlSubscriber.php(119): Drupal\Core\EventSubscriber\DefaultExceptionHtmlSubscriber->makeSubrequest(Object(Symfony\Component\HttpKernel\Event\ExceptionEvent), '/node/24783', 404)
#19 /code/web/core/lib/Drupal/Core/EventSubscriber/CustomPageExceptionHtmlSubscriber.php(81): Drupal\Core\EventSubscriber\CustomPageExceptionHtmlSubscriber->makeSubrequestToCustomPath(Object(Symfony\Component\HttpKernel\Event\ExceptionEvent), '/node/24783', 404)
#20 /code/web/core/lib/Drupal/Core/EventSubscriber/HttpExceptionSubscriberBase.php(109): Drupal\Core\EventSubscriber\CustomPageExceptionHtmlSubscriber->on404(Object(Symfony\Component\HttpKernel\Event\ExceptionEvent))
#21 [internal function]: Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase->onException(Object(Symfony\Component\HttpKernel\Event\ExceptionEvent), 'kernel.exceptio...', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#22 /code/web/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php(111): call_user_func(Array, Object(Symfony\Component\HttpKernel\Event\ExceptionEvent), 'kernel.exceptio...', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#23 /code/vendor/symfony/http-kernel/HttpKernel.php(239): Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\ExceptionEvent), 'kernel.exceptio...')
#24 /code/vendor/symfony/http-kernel/HttpKernel.php(91): Symfony\Component\HttpKernel\HttpKernel->handleThrowable(Object(Symfony\Component\HttpKernel\Exception\NotFoundHttpException), Object(Symfony\Component\HttpFoundation\Request), 1)
#25 /code/web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#26 /code/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#27 /code/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#28 /code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(191): Drupal\Core\StackMiddleware\ContentLength->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#29 /code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(128): Drupal\page_cache\StackMiddleware\PageCache->fetch(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#30 /code/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(82): Drupal\page_cache\StackMiddleware\PageCache->lookup(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#31 /code/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#32 /code/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#33 /code/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#34 /code/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\Core\StackMiddleware\AjaxPageState->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#35 /code/web/core/lib/Drupal/Core/DrupalKernel.php(704): Drupal\Core\StackMiddleware\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#36 /code/web/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#37 {main}
```

Looks like we probably ought to be using core's `current_route_match` service instead of manually trying to get the route name.

Also contains some whitespace fixes.